### PR TITLE
Revert yellow/green swap

### DIFF
--- a/dracula.yaml
+++ b/dracula.yaml
@@ -5,7 +5,7 @@ base01: "3a3c4e"
 base02: "4d4f68"
 base03: "626483"
 base04: "62d6e8"
-base05: "e9e9f4" #forground
+base05: "e9e9f4" #foreground
 base06: "f1f2f8"
 base07: "f7f7fb"
 base08: "ea51b2"


### PR DESCRIPTION
The color names do not need to be strictly adhered to, as per the base16 page: "scheme designers should pick whichever colors they desire, e.g. base0B (green by default) could be replaced with red."

http://chriskempson.com/projects/base16/

Unfortunately, the swap of yellow/green has resulted in base16 no longer being consistent with the other Dracula themes. e.g. yellow is commonly used for strings in Dracula, which is base0B in base16.