### PR TITLE
Adjust colors for consistency

### DIFF
--- a/dracula.yaml
+++ b/dracula.yaml
@@ -8,11 +8,11 @@ base04: '#A4FFFF' # Dark Foreground (status bars)
 base05: '#F8F8F2' # Default Foreground, Caret, Delimiters, Operators
 base06: '#F8F8F2' # Light Foreground
 base07: '#F8F8F2' # Light Background
-base08: '#FF79C6' # Variables, XML Tags, Markup Link Text, Markup Lists, Diff Deleted
+base08: '#8BE9FD' # Variables, XML Tags, Markup Link Text, Markup Lists, Diff Deleted
 base09: '#BD93F9' # Integers, Boolean, Constants, XML Attributes, Markup Link Url
 base0A: '#50FA7B' # Classes, Markup Bold, Search Text Background
 base0B: '#F1FA8C' # Strings, Inherited Class, Markup Code, Diff Inserted
-base0C: '#8BE9FD' # Support, Regular Expressions, Escape Character, Markup Quotes
-base0D: '#D6ACFF' # Functions, Methods, Attribute IDs, Headings
-base0E: '#FF92DF' # Keywors, Storage, Selector, Markup Italic, Diff Changed
-base0F: '#FF6E6E' # Deprecated, Opening/Closing Embedded Language Tags
+base0C: '#FFB86C' # Support, Regular Expressions, Escape Character, Markup Quotes
+base0D: '#50FA7B' # Functions, Methods, Attribute IDs, Headings
+base0E: '#FF79C6' # Keywords, Storage, Selector, Markup Italic, Diff Changed
+base0F: '#FF5555' # Deprecated, Opening/Closing Embedded Language Tags


### PR DESCRIPTION
The colors were taken from the palette in https://github.com/dracula/dracula-theme

Cyan has been used for variables as it's what I've seen across the theme for Vim, Pygments and Atom. Similar reasoning for pink on keywords and green on functions.

Orange and red I didn't see much of. I might try playing about with this for a bit to see the results.