### PR TITLE
Match Dracula Color Palette

### DIFF
--- a/dracula.yaml
+++ b/dracula.yaml
@@ -1,18 +1,18 @@
 scheme: "Dracula"
 author: "Mike Barkmin (http://github.com/mikebarkmin) based on Dracula Theme (http://github.com/dracula)"
-base00: "282936" #background
-base01: "3a3c4e"
-base02: "4d4f68"
-base03: "626483"
-base04: "62d6e8"
-base05: "e9e9f4" #foreground
-base06: "f1f2f8"
-base07: "f7f7fb"
-base08: "ea51b2"
-base09: "b45bcf"
-base0A: "00f769"
-base0B: "ebff87"
-base0C: "a1efe4"
-base0D: "62d6e8"
-base0E: "b45bcf"
-base0F: "00f769"
+base00: "282a36" # Background
+base01: "343746" # Lighter Background
+base02: "44475a" # Selection
+base03: "6272a4" # Comments
+base04: "999999" # Dark Foreground (status bars)
+base05: "f8f8f2" # Foreground
+base06: "f8f8f2" # Light Foreground
+base07: "f8f8f2" # Light Background
+base08: "ff5555" # Red
+base09: "bd93f9" # Purple
+base0A: "f1fa8c" # Yellow
+base0B: "50fa7b" # Green
+base0C: "8be9fd" # Cyan
+base0D: "66d9ef" # Blue (Soft Cyan from Atom)
+base0E: "ff79c6" # Pink
+base0F: "ffb86c" # Orange


### PR DESCRIPTION
After some playing around with building this color scheme, I've come to realize that attempting to match syntax highlighting behavior with other Dracula themes is not a good way to approach this.

I've updated all the colors to match the descriptions with the main Dracula color palette, and included an extra color which was taken from the Atom theme.